### PR TITLE
Add customization options for Macaron theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Built for people who think browsers should feel fun again.
 
 ---
 
+## Local Options
+
+- Accent presets: Strawberry, Pistachio, Blueberry, Vanilla, Matcha.
+- Shadow intensity: None, Soft, Classic, Chunky.
+- Browser spacing: Macaron, Tight, Marginless.
+- Macaron URL bar popup styling.
+- Doodle pack: Coffee, Star, Flower, None.
+- Reduced motion toggle.
+
+---
+
 ## Preview
 
 > *"what if Nintendo and Teenage Engineering made a browser for designers?"*

--- a/modules/marginless.css
+++ b/modules/marginless.css
@@ -1,0 +1,84 @@
+/* Marginless browser mode */
+
+@media (-moz-pref("mac.marginless-browser")), (-moz-pref("mac.marginless-mode", 2)) {
+  :root {
+    --zen-element-separation: 0px !important;
+    --zen-webview-border-radius: 0px !important;
+  }
+
+  :root:not([inDOMFullscreen="true"]) #zen-browser-background {
+    border: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  #browser,
+  #tabbrowser-tabbox,
+  #tabbrowser-tabpanels,
+  #tabbrowser-tabpanels > .browserSidebarContainer,
+  .browserSidebarContainer,
+  .browserStack {
+    margin: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+
+  #tabbrowser-tabpanels {
+    border: 0 !important;
+    overflow: hidden !important;
+  }
+
+  #tabbrowser-tabpanels > .browserSidebarContainer,
+  .browserSidebarContainer {
+    overflow: hidden !important;
+  }
+
+  :root:not([zen-compact-mode="true"]) #navigator-toolbox {
+    padding-right: 0 !important;
+  }
+
+  :root[zen-compact-mode="true"] #titlebar {
+    margin: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  :root[zen-compact-mode="true"] #titlebar:hover,
+  :root[zen-compact-mode="true"]:has(#titlebar:hover) #urlbar {
+    transform: none !important;
+  }
+
+  :root:has(.tabbrowser-tab:active) #tabbrowser-tabpanels {
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+
+@media (-moz-pref("mac.marginless-mode", 1)) {
+  :root {
+    --zen-element-separation: 4px !important;
+    --zen-webview-border-radius: 6px !important;
+  }
+
+  :root:not([inDOMFullscreen="true"]) #zen-browser-background {
+    border-width: 1px !important;
+    border-radius: 6px !important;
+  }
+
+  #tabbrowser-tabpanels {
+    margin-right: 1px !important;
+    margin-bottom: 1px !important;
+    border-width: 1px !important;
+    border-radius: 6px !important;
+    box-shadow: 1px 1px 0 currentColor !important;
+  }
+
+  .browserSidebarContainer,
+  .browserStack {
+    border-radius: 6px !important;
+  }
+
+  :root[zen-compact-mode="true"] #titlebar {
+    margin: 6px !important;
+    border-radius: 6px !important;
+    box-shadow: 1px 1px 0 currentColor !important;
+  }
+}

--- a/modules/style-options.css
+++ b/modules/style-options.css
@@ -1,0 +1,271 @@
+/* Macaron optional style controls */
+
+:root {
+  --mac-accent: #ffb3c1;
+  --mac-accent-2: #fff1d6;
+  --mac-accent-3: #bde0fe;
+  --mac-shadow-size: 4px;
+  --mac-shadow-strong: 6px;
+  --mac-shadow-soft: 2px;
+}
+
+@media (-moz-pref("mac.shadow-level", 0)) {
+  :root {
+    --mac-shadow-size: 0px;
+    --mac-shadow-strong: 0px;
+    --mac-shadow-soft: 0px;
+  }
+}
+
+@media (-moz-pref("mac.shadow-level", 1)) {
+  :root {
+    --mac-shadow-size: 2px;
+    --mac-shadow-strong: 3px;
+    --mac-shadow-soft: 1px;
+  }
+}
+
+@media (-moz-pref("mac.shadow-level", 3)) {
+  :root {
+    --mac-shadow-size: 6px;
+    --mac-shadow-strong: 8px;
+    --mac-shadow-soft: 3px;
+  }
+}
+
+@media (-moz-pref("mac.accent-preset", "strawberry")) {
+  :root {
+    --mac-accent: #ff9eb5;
+    --mac-accent-2: #fff1d6;
+    --mac-accent-3: #bde0fe;
+  }
+}
+
+@media (-moz-pref("mac.accent-preset", "pistachio")) {
+  :root {
+    --mac-accent: #b8e986;
+    --mac-accent-2: #fff5bf;
+    --mac-accent-3: #9adbc8;
+  }
+}
+
+@media (-moz-pref("mac.accent-preset", "blueberry")) {
+  :root {
+    --mac-accent: #a7c7ff;
+    --mac-accent-2: #e8dcff;
+    --mac-accent-3: #9ae6ff;
+  }
+}
+
+@media (-moz-pref("mac.accent-preset", "vanilla")) {
+  :root {
+    --mac-accent: #ffe6a7;
+    --mac-accent-2: #fff8dc;
+    --mac-accent-3: #ffc7a7;
+  }
+}
+
+@media (-moz-pref("mac.accent-preset", "matcha")) {
+  :root {
+    --mac-accent: #9fd8a8;
+    --mac-accent-2: #e8f5c8;
+    --mac-accent-3: #c4e3b1;
+  }
+}
+
+/* Apply accent without flattening the theme's currentColor linework. */
+tab[selected="true"] .tab-background,
+tab[pinned="true"][selected="true"] .tab-background,
+tab[zen-essential="true"][selected="true"] .tab-background,
+zen-folder:not([collapsed]) .tab-group-label-container,
+#zen-media-controls-toolbar.playing,
+#urlbar[breakout][breakout-extend="true"] {
+  background: color-mix(in srgb, var(--mac-accent) 60%, var(--zen-primary-color) 40%) !important;
+}
+
+zen-folder[collapsed] .tab-group-label-container {
+  background: color-mix(in srgb, var(--mac-accent-2) 55%, var(--zen-primary-color) 45%) !important;
+}
+
+@media (-moz-pref("mac.blank.checkboard")) {
+  #browser:has([zen-empty-tab="true"][selected="true"]) .browserStack {
+    background-color: color-mix(in srgb, var(--mac-accent-3) 18%, transparent) !important;
+  }
+}
+
+/* Shadow intensity */
+tab[zen-essential="true"] .tab-background,
+tab[pinned="true"] .tab-background,
+#tabs-newtab-button,
+zen-folder[collapsed] .tab-group-label-container,
+#urlbar:not([breakout-extend="true"]) {
+  box-shadow: var(--mac-shadow-size) var(--mac-shadow-size) 0 currentColor !important;
+}
+
+#urlbar[breakout][breakout-extend="true"] {
+  box-shadow: var(--mac-shadow-strong) var(--mac-shadow-strong) 0 currentColor !important;
+}
+
+tab:not([pinned="true"]):not([zen-essential="true"]) .tab-background,
+#zen-media-controls-toolbar.playing {
+  box-shadow: var(--mac-shadow-soft) var(--mac-shadow-soft) 0 currentColor !important;
+}
+
+/* Consistent pressed surfaces */
+#zen-sidebar-top-buttons toolbarbutton,
+#zen-workspaces-button toolbarbutton,
+#zen-workspaces-button .subviewbutton,
+#unified-extensions-button,
+#PanelUI-menu-button,
+#reload-button,
+#back-button,
+#forward-button,
+#stop-reload-button,
+#downloads-button {
+  border: 2px solid transparent !important;
+  border-radius: 10px !important;
+  transition:
+    transform 0.1s ease,
+    box-shadow 0.1s ease,
+    background-color 0.1s ease !important;
+}
+
+#zen-sidebar-top-buttons toolbarbutton:hover,
+#zen-workspaces-button toolbarbutton:hover,
+#zen-workspaces-button .subviewbutton:hover,
+#unified-extensions-button:hover,
+#PanelUI-menu-button:hover,
+#reload-button:hover,
+#back-button:hover,
+#forward-button:hover,
+#stop-reload-button:hover,
+#downloads-button:hover {
+  border-color: currentColor !important;
+  box-shadow: var(--mac-shadow-soft) var(--mac-shadow-soft) 0 currentColor !important;
+  background: color-mix(in srgb, var(--mac-accent) 25%, transparent) !important;
+}
+
+#zen-sidebar-top-buttons toolbarbutton:active,
+#zen-workspaces-button toolbarbutton:active,
+#zen-workspaces-button .subviewbutton:active,
+#unified-extensions-button:active,
+#PanelUI-menu-button:active,
+#reload-button:active,
+#back-button:active,
+#forward-button:active,
+#stop-reload-button:active,
+#downloads-button:active {
+  transform: translate(var(--mac-shadow-soft), var(--mac-shadow-soft)) !important;
+  box-shadow: none !important;
+}
+
+/* Macaron URL bar popup */
+@media (-moz-pref("mac.urlbar-popup")) {
+  #urlbar[breakout][breakout-extend="true"] {
+    border: 3px solid currentColor !important;
+    border-radius: 14px !important;
+    background: color-mix(in srgb, var(--zen-primary-color) 86%, var(--mac-accent) 14%) !important;
+    box-shadow: var(--mac-shadow-strong) var(--mac-shadow-strong) 0 currentColor !important;
+    overflow: hidden !important;
+  }
+
+  #urlbar[breakout][breakout-extend="true"] .urlbar-background {
+    background: transparent !important;
+    border-radius: inherit !important;
+  }
+
+  #urlbar[open] > .urlbarView > .urlbarView-body-outer {
+    border-top: 2px solid currentColor !important;
+  }
+
+  .urlbarView-row {
+    border: 2px solid transparent !important;
+    border-radius: 10px !important;
+    margin-block: 3px !important;
+  }
+
+  .urlbarView-row:hover,
+  .urlbarView-row[selected] {
+    border-color: currentColor !important;
+    background: color-mix(in srgb, var(--mac-accent) 28%, transparent) !important;
+    box-shadow: var(--mac-shadow-soft) var(--mac-shadow-soft) 0 currentColor !important;
+  }
+
+  .urlbarView-row[selected] .urlbarView-row-inner {
+    transform: translate(1px, 1px) !important;
+  }
+}
+
+/* Optional doodle pack */
+@media (-moz-pref("mac.doodles")) {
+  @media (-moz-pref("mac.doodle-pack", "none")) {
+    #nav-bar::before,
+    .zen-current-workspace-indicator::after {
+      display: none !important;
+    }
+  }
+
+  @media (-moz-pref("mac.doodle-pack", "star")) {
+    #nav-bar::before,
+    .zen-current-workspace-indicator::after {
+      background: none !important;
+      color: currentColor !important;
+      font-size: 22px !important;
+      line-height: 1 !important;
+      text-align: center !important;
+    }
+
+    #nav-bar::before {
+      content: "*" !important;
+    }
+
+    .zen-current-workspace-indicator::after {
+      content: "+" !important;
+    }
+  }
+
+  @media (-moz-pref("mac.doodle-pack", "flower")) {
+    #nav-bar::before,
+    .zen-current-workspace-indicator::after {
+      background: none !important;
+      color: currentColor !important;
+      font-size: 21px !important;
+      line-height: 1 !important;
+      text-align: center !important;
+    }
+
+    #nav-bar::before {
+      content: "x" !important;
+      transform: rotate(45deg) !important;
+    }
+
+    .zen-current-workspace-indicator::after {
+      content: "." !important;
+      border: 2px solid currentColor !important;
+      border-radius: 50% !important;
+    }
+  }
+}
+
+/* Reduced motion */
+@media (-moz-pref("mac.reduced-motion")) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  tab,
+  tab *,
+  #urlbar,
+  #urlbar *,
+  #tabbrowser-tabpanels,
+  #titlebar,
+  #zen-media-controls-toolbar,
+  .titlebar-button {
+    transform: none !important;
+  }
+}

--- a/preferences.json
+++ b/preferences.json
@@ -5,6 +5,48 @@
     "size": "20px",
     "margin": "20px 0 30px 0"
   },
+
+  {
+    "type": "separator",
+    "label": "Visual Style",
+    "margin": "15px 0"
+  },
+
+  {
+    "type": "dropdown",
+    "property": "mac.accent-preset",
+    "label": "Accent preset",
+    "value": "string",
+    "defaultValue": "strawberry",
+    "options": [
+      { "value": "strawberry", "label": "Strawberry" },
+      { "value": "pistachio", "label": "Pistachio" },
+      { "value": "blueberry", "label": "Blueberry" },
+      { "value": "vanilla", "label": "Vanilla" },
+      { "value": "matcha", "label": "Matcha" }
+    ]
+  },
+
+  {
+    "type": "dropdown",
+    "property": "mac.shadow-level",
+    "label": "Shadow intensity",
+    "value": "number",
+    "defaultValue": 2,
+    "options": [
+      { "value": 0, "label": "None" },
+      { "value": 1, "label": "Soft" },
+      { "value": 2, "label": "Classic" },
+      { "value": 3, "label": "Chunky" }
+    ]
+  },
+
+  {
+    "type": "checkbox",
+    "property": "mac.urlbar-popup",
+    "label": "Enable Macaron URL bar popup",
+    "defaultValue": true
+  },
   
   {
     "type": "separator",
@@ -27,6 +69,25 @@
     "defaultValue": "0.35",
     "placeholder": "0.35"
   },
+
+  {
+    "type": "separator",
+    "label": "Browser Layout",
+    "margin": "15px 0"
+  },
+
+  {
+    "type": "dropdown",
+    "property": "mac.marginless-mode",
+    "label": "Browser spacing",
+    "value": "number",
+    "defaultValue": 0,
+    "options": [
+      { "value": 0, "label": "Macaron" },
+      { "value": 1, "label": "Tight" },
+      { "value": 2, "label": "Marginless" }
+    ]
+  },
   
   {
     "type": "separator",
@@ -45,6 +106,27 @@
     "type": "checkbox",
     "property": "mac.doodles",
     "label": "Enable doodles!",
+    "defaultValue": false
+  },
+
+  {
+    "type": "dropdown",
+    "property": "mac.doodle-pack",
+    "label": "Doodle pack",
+    "value": "string",
+    "defaultValue": "coffee",
+    "options": [
+      { "value": "coffee", "label": "Coffee" },
+      { "value": "star", "label": "Star" },
+      { "value": "flower", "label": "Flower" },
+      { "value": "none", "label": "None" }
+    ]
+  },
+
+  {
+    "type": "checkbox",
+    "property": "mac.reduced-motion",
+    "label": "Reduce motion",
     "defaultValue": false
   },
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -7,3 +7,5 @@
 @import url("modules/urlbar.css");
 @import url("modules/font.css");
 @import url("modules/webview.css");
+@import url("modules/marginless.css");
+@import url("modules/style-options.css");


### PR DESCRIPTION
## Summary

This PR adds a set of optional customization controls while keeping Macaron's default playful neo-brutalist look intact.

### Added

- Accent presets: Strawberry, Pistachio, Blueberry, Vanilla, and Matcha.
- Shadow intensity controls: None, Soft, Classic, and Chunky.
- Browser spacing controls: default Macaron spacing, Tight mode, and full Marginless mode.
- Optional Macaron-styled URL bar popup treatment.
- Doodle pack selection: Coffee, Star, Flower, and None.
- Reduced motion toggle for users who prefer less animation.
- More consistent pressed/hover treatment for sidebar, workspace, extension, and navigation buttons.

### Files changed

- `preferences.json`: adds the new user-facing settings and groups them into clearer sections.
- `userChrome.css`: imports the new option modules.
- `modules/marginless.css`: adds Tight and Marginless browser layout modes.
- `modules/style-options.css`: contains accent presets, shadow controls, URL bar popup styling, doodle variants, pressed UI consistency, and reduced motion support.
- `README.md`: documents the new local options.

## Why

Macaron already has a strong tactile identity. These changes make that identity more configurable without forcing a single look on every user. The default values preserve the existing style, while users can opt into tighter spacing, reduced motion, different accent flavors, or a more polished URL bar popup.

## Validation

- Parsed `preferences.json` successfully.
- Checked CSS brace balance for all module CSS files and `userChrome.css`.
- Verified the new imports resolve locally.
- Compared `Khf20:main` against upstream `main`; the branch is 1 commit ahead and 0 commits behind.