### PR TITLE
Fix readme link to be raw

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -7,7 +7,7 @@
   "version": "1.5.2",
   "createdAt": "2026-04-27",
   "updatedAt": "2026-05-21",
-  "readme": "https://github.com/SehajveerSingh2005/macaron/blob/main/README.md",
+  "readme": "https://raw.githubusercontent.com/SehajveerSingh2005/macaron/main/README.md",
   "image": "https://private-user-images.githubusercontent.com/156107192/585564291-08be252f-6bca-4dde-9429-52f676ac854b.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzc2NDYwMzIsIm5iZiI6MTc3NzY0NTczMiwicGF0aCI6Ii8xNTYxMDcxOTIvNTg1NTY0MjkxLTA4YmUyNTJmLTZiY2EtNGRkZS05NDI5LTUyZjY3NmFjODU0Yi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNTAxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDUwMVQxNDI4NTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT03YjE3OGM3Y2Y1YTBkMmE0MzRmZDQ4M2VlZDBlZmMwMTI2MmNkNTg2YjU2ZWZmN2ZjMDg5MTYzYWVlZGViMzEyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9aW1hZ2UlMkZwbmcifQ._bqLS-F3xtyQTP-aBF87_7ymdCu3-pFOGbWaZohLWyA",
   "tags": [
     "Theme",


### PR DESCRIPTION
Currently the README link points to the blob URL, which completely breaks Sine's README parsing. This will switch the link to be a `raw.githubusercontent.com` link instead so it will fetch only the raw README data.